### PR TITLE
Create Ewon Java Ant Build Action

### DIFF
--- a/ewon-java-build-ant.yml
+++ b/ewon-java-build-ant.yml
@@ -1,0 +1,76 @@
+# HMS Networks Solution Center
+# Ewon JTK Java Build Script for GitHub Actions
+# Version: 1.0pre
+
+name: Ewon Java Build
+
+env:
+  SRC_FOLDERS: src libs
+  ETK_URL: https://github.com/hms-networks/GitHub-Actions-Generic/raw/main/libs/ewon-java-etk-1.4.4.jar
+  ETK_LOCAL_FILE_NAME: ewon-java-etk.jar
+  TMP_CP_FOLDER: tmp_classpath
+  TMP_JAVADOC_FOLDER: tmp_javadocs
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set Up JDK v1.8 (Ubuntu)
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Create Temporary Classpath Folder (Ubuntu)
+      run: mkdir ./$TMP_CP_FOLDER
+
+    - name: Create Build Output Directory (Ubuntu)
+      run: mkdir ./bin
+
+    - name: Download Ewon ETK from hms-networks/GitHub-Actions-Generic/libs/ (Ubuntu)
+      run: curl -o ./$TMP_CP_FOLDER/$ETK_LOCAL_FILE_NAME -L $ETK_URL
+
+    - name: Configure Permissions of Temporary Classpath Folder (Ubuntu)
+      run: chmod -R +rwx ./$TMP_CP_FOLDER
+
+    - name: Build Java Files in /src and /libs with Target/Source of 1.4 (Ubuntu)
+      run: javac -source 1.4 -target 1.4 -cp ./$TMP_CP_FOLDER/$ETK_LOCAL_FILE_NAME -d bin $(find $SRC_FOLDERS -name "*.java")
+
+    - name: Generate Javadocs for Java Files in /src and /libs (Ubuntu)
+      run: javadoc -private -splitindex -use -author -version -d .\$TMP_JAVADOC_FOLDER -classpath ./$TMP_CP_FOLDER/$ETK_LOCAL_FILE_NAME $(find $SRC_FOLDERS -name "*.java")
+
+    - name: Build Ewon Jar in Ant (Ubuntu)
+      run: ant "buildjar" -noinput -buildfile build.xml
+    
+    - name: Parse Ant Build File for Project Name (Ubuntu)
+      run: |
+        export PROJECTNAME=$(sed -n 's/<property name=\"ProjectName\"\ value=\"\(.*\)\"\/>/\1/p' build.xml | tr -d '[:space:]')
+        echo "::set-env name=PROJECT_NAME::$PROJECTNAME"
+        
+    - name: Get Current Time for Artifact Identification (Ubuntu)
+      id: time
+      uses: nanzm/get-time-action@v1.0
+      with:
+        timeZone: 0
+        format: 'YYYY-MM-DD-HH-mm-ss'
+    
+    - name: Upload Ewon Jar as Artifact (Ubuntu)
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}-JAR-BUILD${{ steps.time.outputs.time }}UTC
+        path: build/${{ env.PROJECT_NAME }}.jar
+        
+    - name: Upload Ewon Jar Javadocs as Artifact (Ubuntu)
+      uses: actions/upload-artifact@v2
+      with:
+        name: ${{ github.event.repository.name }}-JAVADOCS-BUILD${{ steps.time.outputs.time }}UTC
+        path: .\$TMP_JAVADOC_FOLDER


### PR DESCRIPTION
This GitHub Action can be added to repositories that use an Ewon ETK Java Project with build.xml to allow for test building of Java source code and automatic artifact creation for .jar file and associated Javadocs.