### PR TITLE
Created Ewon library release build action

### DIFF
--- a/ewon-java-lib-build-release.yml
+++ b/ewon-java-lib-build-release.yml
@@ -1,0 +1,67 @@
+# HMS Networks Solution Center
+# Ewon JTK Java Library Release Script for GitHub Actions
+# Version: 1.0
+
+name: Ewon Java Library Release Build
+
+env:
+  SRC_FOLDER: src
+  ETK_URL: https://github.com/hms-networks/GitHub-Actions-Generic/raw/main/libs/ewon-java-etk-1.4.4.jar
+  ETK_LOCAL_FILE_NAME: ewon-java-etk.jar
+  TMP_CP_FOLDER: tmp_classpath
+  TMP_JAVADOC_FOLDER: doc
+  README_NAME: README.md
+  LICENSE_NAME: LICENSE
+
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0
+
+jobs:
+  build:
+    name: Upload Release Asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set Up JDK v1.8 (Ubuntu)
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Create Temporary Classpath Folder (Ubuntu)
+        run: mkdir ./$TMP_CP_FOLDER
+
+      - name: Download Ewon ETK from hms-networks/GitHub-Actions-Generic/libs/ (Ubuntu)
+        run: curl -o ./$TMP_CP_FOLDER/$ETK_LOCAL_FILE_NAME -L $ETK_URL
+
+      - name: Generate Javadocs for Java Files in /src and /libs (Ubuntu)
+        run: javadoc -private -splitindex -use -author -version -d $TMP_JAVADOC_FOLDER -classpath ./$TMP_CP_FOLDER/$ETK_LOCAL_FILE_NAME $(find $SRC_FOLDER -name "*.java")
+
+      - name: Build Release
+        run: |
+          zip release -r $README_NAME $LICENSE_NAME $SRC_FOLDER $TMP_JAVADOC_FOLDER
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./release.zip
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
This Github action will create a new release whenever a tag
is pushed that starts with a v, ex v1.0. This release will
include a zip containing the readme, license, source, and
javadocs.