### PR TITLE
Created Ewon library release branch action

### DIFF
--- a/ewon-java-lib-release-branch.yml
+++ b/ewon-java-lib-release-branch.yml
@@ -1,0 +1,33 @@
+# HMS Networks Solution Center
+# Ewon JTK Java Library Release Branch Script for GitHub Actions
+# Version: 1.0
+
+name: Ewon Java Library Release Branch Builder
+
+on:
+  push:
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  build:
+    name: Create Release Branch
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Branch name # Build a branch name from tag (vX.Y) in release/X.Y format
+        id: branch_name
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          tagRevision="${tag:1}"
+          branchPrefix="release/"
+          branchName="$branchPrefix$tagRevision"
+          echo ::set-output name=SOURCE_TAG::"$branchName"
+
+      - name: Create Branch
+        uses: peterjgrainger/action-create-branch@v2.0.1
+        with:
+          branch: ${{ steps.branch_name.outputs.SOURCE_TAG }}


### PR DESCRIPTION
This github action will create a release branch for all versioned
tags. If a tag is pushed that starts with v a new branch will be Created
with the branch name release/X.Y where X is the major version number
and y is the minor version number (taken from the tag name).